### PR TITLE
rename npm package name to match the pantry name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test-pantry",
+  "name": "deliciousness",
   "license": "UNLICENSED",
   "repository": {
     "type": "git"


### PR DESCRIPTION
this will allow the bechamel cli to automatically determine the pantry name when passed a path to the pantry root